### PR TITLE
Fix incorrect menu images

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -115,7 +115,7 @@
     {
       "name": "C10. Chicken with Mixed Vegetable 什菜鸡",
       "price": "$12.19",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "C11. Shrimp Chow Mein 虾炒面",
@@ -150,7 +150,7 @@
     {
       "name": "C15. Shrimp with Chinese Vegetable 白菜虾",
       "price": "$12.59",
-      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "C16. Chicken with Black Pepper 黑椒鸡",
@@ -180,7 +180,7 @@
     {
       "name": "C20. Roast Pork Egg Foo Young 叉烧蓉蛋",
       "price": "$12.59",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1582878826629-29b7ad1cdc43?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "C21. Bourbon Chicken 棒棒鸡",
@@ -257,7 +257,7 @@
     {
       "name": "25. Vegetable Fried Rice 菜炒饭",
       "price": "$7.39",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "26. Roast Pork Fried Rice 叉烧炒饭",
@@ -272,12 +272,12 @@
     {
       "name": "28. Beef Fried Rice 牛炒饭",
       "price": "$9.19",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "29. Shrimp Fried Rice 虾炒饭",
       "price": "$11.29",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "30. Crab Meat Fried Rice 蟹肉炒饭",
@@ -304,7 +304,7 @@
     {
       "name": "35. Roast Pork Lo Mein 叉烧捞面",
       "price": "$7.79",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "35a. Chicken Lo Mein 鸡捞面",
@@ -351,17 +351,17 @@
     {
       "name": "4. Steamed Chicken with Vegetables 煮什菜鸡",
       "price": "$13.49",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "5. Chicken with Mixed Vegetable 什菜鸡",
       "price": "$9.99",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "6. Sweet & Sour Shrimp 甜酸虾",
       "price": "$10.29",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "7. Pepper Chicken with Onion 青椒鸡",
@@ -396,12 +396,12 @@
     {
       "name": "12. Roast Pork with Chinese Vegetable 白菜叉烧",
       "price": "$9.99",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "13. Roast Pork Egg Foo Young 叉烧蓉蛋",
       "price": "$9.99",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1582878826629-29b7ad1cdc43?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "14. Roast Pork with Snow Peas 雪豆叉烧",
@@ -446,7 +446,7 @@
     {
       "name": "21. Shrimp with Chinese Vegetable 白菜虾",
       "price": "$10.29",
-      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "22.Shrimp with Lobster Sauce 虾龙糊",
@@ -618,7 +618,7 @@
     {
       "name": "H16. Scallop & Beef 干贝牛",
       "price": "$17.29",
-      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "H17. Triple Delight with Garlic Sauce 鱼香三样",
@@ -670,7 +670,7 @@
     {
       "name": "2. Shrimp Roll (1) 虾卷",
       "price": "$2.79",
-      "image": "https://images.unsplash.com/photo-1585032226651-759b368d7246?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "3. Spring Roll (2) 上海卷",
@@ -772,7 +772,7 @@
     {
       "name": "21. Tofu with Mixed Vegetable Soup 豆腐什菜汤",
       "price": "$4.19",
-      "image": "https://images.unsplash.com/photo-1547592180-85f173990554?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1616190174793-4d96d5b8e7e3?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "22. House Special Soup 本楼汤",
@@ -814,7 +814,7 @@
     {
       "name": "88. Chicken with Mixed Vegetable 什菜鸡",
       "price": "$9.79",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "89. Chicken with Snow Peas 雪豆鸡",
@@ -921,12 +921,12 @@
     {
       "name": "119. Beef with Mixed Vegetable 什菜牛",
       "price": "$10.19",
-      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "120. Beef with Chines Vegetable 白菜牛",
       "price": "$10.19",
-      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "121. Beef with Snow Peas 雪豆牛",
@@ -961,7 +961,7 @@
     {
       "name": "127. Kung Pao Beef 宫保牛",
       "price": "$13.69",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "128. Mongolian Beef 蒙古牛",
@@ -978,7 +978,7 @@
     {
       "name": "130. Shrimp with Chinese Vegetable 白菜虾",
       "price": "$9.99",
-      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "131. Shrimp with Oyster Sauce 蚝油虾",
@@ -993,7 +993,7 @@
     {
       "name": "133. Shrimp with Mixed Vegetables 什菜虾",
       "price": "$9.99",
-      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "134. Shrimp with Lobster Sauce 龙虾糊",
@@ -1038,7 +1038,7 @@
     {
       "name": "142. Kung Pao Shrimp 宫保虾",
       "price": "$13.29",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "143. Curry Shrimp 咖喱虾",
@@ -1065,7 +1065,7 @@
     {
       "name": "105. Roast Pork with Broccoli 芥兰叉烧",
       "price": "$9.79",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "106. Roast Pork with Oyster Sauce 蚝油叉烧",
@@ -1075,12 +1075,12 @@
     {
       "name": "107. Roast Pork with Mixed Vegetable 什菜叉烧",
       "price": "$9.79",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "108. Roast Pork with Chinese Vegetable 白菜叉烧",
       "price": "$9.79",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "109. Roast Pork with Snow Pea 雪豆叉烧",
@@ -1137,7 +1137,7 @@
     {
       "name": "74. Bean Curd with Garlic Sauce 鱼香豆腐",
       "price": "$10.99",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1616190174793-4d96d5b8e7e3?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "75. Curry Tofu 咖喱豆腐",
@@ -1157,7 +1157,7 @@
     {
       "name": "78.Bean Curd Szechuan Style 四川豆腐",
       "price": "$10.99",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1616190174793-4d96d5b8e7e3?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     }
   ],
   "Chow Mein": [
@@ -1169,7 +1169,7 @@
     {
       "name": "41. Roast Pork Chow Mein 叉烧炒面",
       "price": "$7.59",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "41a. Chicken Chow Mein 鸡炒面",
@@ -1201,7 +1201,7 @@
     {
       "name": "46. Vegetable Chop Suey 菜什碎",
       "price": "$7.59",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "47. Roast Pork Chop Suey 叉烧什碎",
@@ -1216,12 +1216,12 @@
     {
       "name": "48. Beef Chop Suey 牛什碎",
       "price": "$9.19",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "48a. Shrimp Chop Suey 虾什碎",
       "price": "$9.19",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "49. Crab Meat Chop Suey 蟹肉什碎",
@@ -1248,7 +1248,7 @@
     {
       "name": "54. Sweet & Sour Shrimp 甜酸虾",
       "price": "$8.99",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "55. Sweet & Sour Combo 甜酸三宝",
@@ -1265,7 +1265,7 @@
     {
       "name": "57. Roast Pork Egg Foo Young 叉烧蓉蛋",
       "price": "$11.49",
-      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1582878826629-29b7ad1cdc43?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "57a. Chicken Egg Foo Young 鸡蓉蛋",
@@ -1344,12 +1344,12 @@
     {
       "name": "79. Moo Shu Vegetable 木须菜",
       "price": "$12.29",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "80. Moo Shu Pork 木须肉",
       "price": "$12.59",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1604503468506-a8da13d82791?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "81. Moo Shu Chicken 木须鸡",
@@ -1359,12 +1359,12 @@
     {
       "name": "82. Moo Shu Beef 木须牛",
       "price": "$13.09",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "83. Moo Shu Shrimp 木须虾",
       "price": "$13.09",
-      "image": "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     }
   ],
   "Side Orders": [
@@ -1403,17 +1403,17 @@
     {
       "name": "D3. Steamed Chicken with Mixed Vegetable 煮什菜鸡",
       "price": "$13.49",
-      "image": "https://images.unsplash.com/photo-1603133872878-684f208fb84b?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "D4. Steamed Beef with Mixed Vegetable 煮什菜牛",
       "price": "$14.19",
-      "image": "https://images.unsplash.com/photo-1546833999-b9f581a1996d?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "D5. Steamed Shrimp with Mixed Vegetable 煮什菜虾",
       "price": "$13.79",
-      "image": "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
+      "image": "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=80"
     },
     {
       "name": "D6. Steamed Tofu with Mixed Vegetable 煮什菜豆腐",

--- a/script.js
+++ b/script.js
@@ -141,7 +141,7 @@ async function loadMenu() {
             
             menuData[categoryName].forEach(item => {
                 const cleanName = getCleanFoodName(item.name);
-                const imageUrl = getFoodImage(item.name);
+                const imageUrl = item.image || getFoodImage(item.name);
                 
                 const menuItem = document.createElement('div');
                 menuItem.className = 'menu-item';


### PR DESCRIPTION
- Updated `menu.json` to use correct Unsplash images for Beef, Shrimp, Pork, Lo Mein, etc., replacing the incorrect "General Tso's Chicken" default.
- Updated `script.js` to prioritize the `image` field from `menu.json` over the hardcoded `getFoodImage` mapping.
- Ensured `menu.json` preserves UTF-8 characters for dish names.

---
*PR created automatically by Jules for task [1115301520927894394](https://jules.google.com/task/1115301520927894394) started by @osimmov*