### PR TITLE
🛡️ Sentinel: [security improvement] Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-05 - Content Security Policy for Static Sites
+**Vulnerability:** The application lacked a Content Security Policy (CSP), potentially allowing execution of malicious scripts or loading of unauthorized resources if an injection vulnerability were introduced.
+**Learning:** Even static sites can benefit from CSP as a defense-in-depth measure. It requires careful enumeration of all external resources (fonts, images, frames) and removal of inline styles to be effective.
+**Prevention:** Always implement a strict CSP that whitelists only necessary domains and avoids 'unsafe-inline' or 'unsafe-eval' where possible.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com; frame-src https://www.google.com; connect-src 'self';">
     <title>China Garden - Authentic Chinese Cuisine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -53,7 +54,7 @@
                     <p>We're conveniently located in downtown Wooster with plenty of parking available.</p>
                 </div>
                 <div class="map-container">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Implemented a Content Security Policy (CSP) as a defense-in-depth measure. 

Changes:
1.  **`index.html`**: Added a `<meta>` tag with a strict CSP.
    -   `default-src 'self'`: Default to local origin.
    -   `script-src 'self'`: Scripts only from local origin.
    -   `style-src 'self' https://fonts.googleapis.com`: Styles from local and Google Fonts.
    -   `font-src https://fonts.gstatic.com`: Fonts from Google.
    -   `img-src 'self' https://images.unsplash.com`: Images from local and Unsplash.
    -   `frame-src https://www.google.com`: Iframes from Google (Maps).
    -   `connect-src 'self'`: AJAX requests to local origin.
2.  **`index.html`**: Removed `style="border:0;"` from the `<iframe>` element. This styling is already present in `style.css` (`.map-container iframe { border: none; }`), and removing the inline style allows us to avoid using `'unsafe-inline'` in the CSP.
3.  **`.jules/sentinel.md`**: Recorded the security enhancement in the Sentinel journal.

Verification:
- Confirmed visually via Playwright screenshot that the map and fonts still load correctly.
- Confirmed via browser console logs (captured by Playwright) that no CSP violations are reported.

---
*PR created automatically by Jules for task [17947258677985013786](https://jules.google.com/task/17947258677985013786) started by @osimmov*