### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Security Journal
+
+## 2026-02-06 - Enforcing Content Security Policy in Legacy HTML
+**Vulnerability:** Missing Content Security Policy (CSP) allowed potential execution of unauthorized scripts and loading of malicious resources.
+**Learning:** Legacy HTML often contains inline styles (e.g., `style="border:0;"` on iframes) which block the implementation of a strict `style-src 'self'` policy. In this case, the inline style was redundant as the CSS already covered it.
+**Prevention:** Audit and move all inline styles to external CSS files. Use `grep` to identify inline styles before implementing CSP.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com; frame-src https://www.google.com; connect-src 'self'; base-uri 'self'; form-action 'self';">
     <title>China Garden - Authentic Chinese Cuisine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -53,7 +54,7 @@
                     <p>We're conveniently located in downtown Wooster with plenty of parking available.</p>
                 </div>
                 <div class="map-container">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR implements a Content Security Policy (CSP) to enhance the security of the application. 

Changes:
1.  **Added CSP Meta Tag**: A strict CSP has been added to `index.html` restricting sources for scripts, styles, fonts, images, and frames to trusted domains ('self', Google, Unsplash).
2.  **Refactored Inline Styles**: Removed `style="border:0;"` from the Google Maps iframe. This inline style was blocking the `style-src 'self'` directive. The existing `style.css` already contains `.map-container iframe { border: none; }`, ensuring no visual change.

Verification:
- Verified that `style.css` covers the removed inline style.
- Verified that the map and other resources load correctly using a frontend verification script.
- Verified that no console errors are generated regarding CSP violations.

---
*PR created automatically by Jules for task [12526860654756337377](https://jules.google.com/task/12526860654756337377) started by @osimmov*