### PR TITLE
🛡️ Sentinel: Add strict Content Security Policy (CSP)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com; frame-src https://www.google.com; object-src 'none'; base-uri 'self'; form-action 'self';">
     <title>China Garden - Authentic Chinese Cuisine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -53,7 +54,7 @@
                     <p>We're conveniently located in downtown Wooster with plenty of parking available.</p>
                 </div>
                 <div class="map-container">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -277,7 +277,7 @@ nav {
 .map-container iframe {
     width: 100%;
     height: 100%;
-    border: none;
+    border: none; /* Replaces inline style="border:0;" for CSP compliance */
 }
 
 /* Contact Section */


### PR DESCRIPTION
Added a strict Content Security Policy (CSP) to mitigate XSS risks and removed inline styles for compliance.

---
*PR created automatically by Jules for task [217611505109494722](https://jules.google.com/task/217611505109494722) started by @osimmov*