### PR TITLE
🛡️ Sentinel: Add Strict Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2025-02-20 - Destructive Parser Script
+**Vulnerability:** The `parser.py` script overwrites `menu.json` with scraped data but fails to preserve existing image URLs, leading to data loss and a broken frontend experience.
+**Learning:** Helper scripts in this repo are not idempotent and can be destructive. They lack validation against existing data structures.
+**Prevention:** Always backup `menu.json` before running `parser.py`. Future improvements should merge new data or preserve existing fields.
+
+## 2025-02-20 - Strict CSP Implementation
+**Vulnerability:** Lack of Content Security Policy allowed potential XSS and data injection.
+**Learning:** The application uses Google Fonts, Google Maps, and Unsplash images. Inline styles were present on the iframe but covered by CSS.
+**Prevention:** Use the established CSP meta tag pattern: `default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; ...`. Ensure all future styles are in `style.css` to maintain strict CSP.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>China Garden - Authentic Chinese Cuisine</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com; frame-src https://www.google.com; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="style.css">
@@ -53,7 +54,7 @@
                     <p>We're conveniently located in downtown Wooster with plenty of parking available.</p>
                 </div>
                 <div class="map-container">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
🛡️ Sentinel: [Security Improvement] Add Strict CSP

## Summary
This PR implements a strict Content Security Policy (CSP) to significantly improve the application's security posture against XSS and data injection attacks.

## Changes
- **`index.html`**: Added a `Content-Security-Policy` meta tag restricting sources for scripts, styles, fonts, images, and frames.
- **`index.html`**: Removed the inline `style="border:0;"` from the Google Maps iframe. This style is redundant as it's already covered by the `.map-container iframe { border: none; }` rule in `style.css`. Removing it allows us to avoid using `'unsafe-inline'` in the CSP.
- **`.jules/sentinel.md`**: Added a journal entry documenting the CSP implementation and a warning about the destructive nature of `parser.py`.

## Verification
- **Code Analysis**: Confirmed that `style.css` contains the rule for the iframe border, ensuring no visual regression.
- **Playwright**: Ran a script verifying that the page loads without any CSP violations in the console.
- **Manual**: Verified that all external resources (Google Fonts, Google Maps, Unsplash images) are correctly allow-listed in the CSP.

## Security Impact
- **XSS Mitigation**: Script execution is restricted to `self`, preventing injection of malicious scripts.
- **Data Injection**: Frame and object sources are restricted, preventing clickjacking and other embedding attacks.


---
*PR created automatically by Jules for task [10190787539094870950](https://jules.google.com/task/10190787539094870950) started by @osimmov*