### PR TITLE
🛡️ Sentinel: [security improvement] Add Content Security Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com data:; frame-src https://www.google.com;">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>China Garden - Authentic Chinese Cuisine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -53,7 +54,7 @@
                     <p>We're conveniently located in downtown Wooster with plenty of parking available.</p>
                 </div>
                 <div class="map-container">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d267.1041986919631!2d-81.93405041724414!3d40.8017371807366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883746611fdcccf9%3A0x304eaf357498e05c!2sChina%20Garden%20Restaurant!5e0!3m2!1sen!2sus!4v1769470677636!5m2!1sen!2sus" width="600" height="450" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Added a Content Security Policy (CSP) meta tag to `index.html` to mitigate XSS and other injection attacks.
The policy whitelists trusted sources for scripts, styles, fonts, images, and frames.
Also removed an inline style from the Google Maps iframe to allow for a stricter policy (no 'unsafe-inline' for styles).

---
*PR created automatically by Jules for task [5292797410299886795](https://jules.google.com/task/5292797410299886795) started by @osimmov*