### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout in parser.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal 🛡️
+
+## 2025-02-18 - Missing Timeout in Parser Script
+**Vulnerability:** `parser.py` uses `requests.get()` without a timeout, which can cause the script to hang indefinitely (DoS) if the remote server is unresponsive.
+**Learning:** Developers often overlook network unreliability in utility scripts, assuming they run in a controlled environment.
+**Prevention:** Enforce mandatory `timeout` parameter for all HTTP requests and handle `RequestException` to fail gracefully.

--- a/parser.py
+++ b/parser.py
@@ -1,6 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 import json
+import sys
 
 URL = "https://www.wooshdelivery.com/order/restaurant/china-garden-menu/87313"
 
@@ -8,7 +9,13 @@ headers = {
     "User-Agent": "Mozilla/5.0"
 }
 
-response = requests.get(URL, headers=headers)
+try:
+    response = requests.get(URL, headers=headers, timeout=10)
+    response.raise_for_status()
+except requests.RequestException as e:
+    print(f"Error fetching menu data: {e}", file=sys.stderr)
+    sys.exit(1)
+
 soup = BeautifulSoup(response.text, "html.parser")
 
 menu = {}


### PR DESCRIPTION
This PR addresses a medium-priority security issue where `parser.py` made a network request without a timeout, potentially causing the script to hang indefinitely (DoS vector).

Changes:
- Added `timeout=10` to `requests.get()`.
- Added robust error handling using `try...except requests.RequestException`.
- Ensures the script exits with a non-zero status code on failure, preventing silent failures or stack trace leakage (to stderr).
- Initialized `.jules/sentinel.md` to document this security learning.

This change follows Sentinel's philosophy of "Fail securely" and defense in depth.

---
*PR created automatically by Jules for task [8476829470436879326](https://jules.google.com/task/8476829470436879326) started by @osimmov*